### PR TITLE
Map timestamp type to db int

### DIFF
--- a/lib/DoctrineTimestamp/DBAL/Types/Timestamp.php
+++ b/lib/DoctrineTimestamp/DBAL/Types/Timestamp.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Definition of the timestamp type for Doctrine 2
  */
@@ -60,11 +61,27 @@ class Timestamp extends Type
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {
-	if(is_null($value)) {
-		return null;
-	}
+        if (is_null($value)) {
+            return null;
+        }
         $dt = new \DateTime();
         $dt->setTimestamp($value);
         return $dt;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getBindingType()
+    {
+        return \PDO::PARAM_INT;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function requiresSQLCommentHint(AbstractPlatform $platform)
+    {
+        return true;
     }
 }


### PR DESCRIPTION
correctly map the Doctrine timestamp type to a SQL integer by adding a type hint on the column comment (DC2Type:timestamp)